### PR TITLE
Improve project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# browserslist extension for Visual Studio Code
+# Browserslist syntax highlight for Visual Studio Code
 
-Syntax highlight [extension](https://marketplace.visualstudio.com/items?itemName=webben.browserslist) for browserslist and .browserslistrc files.
-
-[More about browserslist](https://github.com/browserslist/browserslist)
+Syntax highlight [extension](https://marketplace.visualstudio.com/items?itemName=webben.browserslist) for [Browserslist](https://github.com/browserslist/browserslist) config, `browserslistrc`.
 
 ## Examples
 


### PR DESCRIPTION
1. `browserslist` config name was deprecated. It will be better to not promote it.
2. `extension` → `syntax highlight` in the title explain the benefits to the user.
3. Two paragraphs → one